### PR TITLE
Scope name update

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-@evolutius:registry=https://registry.npmjs.org/
+@evlt:registry=https://registry.npmjs.org/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 API-X includes features like request signing, application authentication, access control, and SSL/TLS enforcement, making it an excellent choice for developers who want to create secure APIs with minimal effort.
 
-Use the [Getting Started](./documentation/Getting_Started.md) document to take the first step.
+Use the [Getting Started](https://apix.evoluti.us/documents/Getting_Started.html) document to take the first step.
+
+Full documentation available at https://apix.evoluti.us/.
 
 ## Pipelines
 <a href="#">

--- a/documentation/Getting_Started.md
+++ b/documentation/Getting_Started.md
@@ -30,19 +30,19 @@ yarn -v
 To install API-X in your project, run the following command:
 
 ```sh
-npm install @evolutius/apix
+npm install @evlt/apix
 ```
 
 Or if you're using yarn:
 
 ```sh
-yarn add @evolutius/apix
+yarn add @evlt/apix
 ```
 
 If you want to try a beta version, run:
 
 ```sh
-npm install @evolutius/apix@beta
+npm install @evlt/apix@beta
 ```
 
 This will install API-X along with all necessary dependencies.
@@ -71,7 +71,7 @@ npx tsc --init
 Ensure you've installed all dependencies:
 
 ```sh
-npm install --save-dev @evolutius/apix express @types/express
+npm install --save-dev @evlt/apix express @types/express
 ```
 
 ### Step 2: Create Your Server
@@ -89,7 +89,7 @@ import {
   ApiXConfig,
   ApiXAccessLevel,
   ApiXRequestInputSchema
-} from '@evolutius/apix';
+} from '@evlt/apix';
 
 import { Request } from 'express';
   

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@evolutius/apix",
+  "name": "@evlt/apix",
   "version": "2.0.0-beta.1",
   "description": "A fast and secure JSON RESTful API",
   "main": "lib/index.js",


### PR DESCRIPTION
Updated the name of the scope from `@evolutius` to `@evlt`.

All new imports must be `@evlt/apix` instead of `@evolutius/apix`.