### PR TITLE
Apix v2 beta2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
-  "name": "@evolutius/apix",
-  "version": "2.0.0",
+  "name": "@evlt/apix",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@evolutius/apix",
-      "version": "2.0.0",
+      "name": "@evlt/apix",
+      "version": "2.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "-": "^0.0.1",
         "@types/express": "^5.0.0",
-        "crypto": "^1.0.1",
         "express": "^4.21.1",
         "redis": "^4.7.0"
       },
@@ -2664,10 +2663,11 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2676,13 +2676,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
-      "license": "ISC"
     },
     "node_modules/cssom": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evlt/apix",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "A fast and secure JSON RESTful API",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -50,7 +50,6 @@
   "dependencies": {
     "-": "^0.0.1",
     "@types/express": "^5.0.0",
-    "crypto": "^1.0.1",
     "express": "^4.21.1",
     "redis": "^4.7.0"
   }

--- a/src/apixlib/ApiXDataManager.ts
+++ b/src/apixlib/ApiXDataManager.ts
@@ -15,5 +15,5 @@ export interface ApiXDataManager {
    * @param apiKey The API key.
    * @returns The App Key or `null`.
    */
-  getAppKeyForApiKey(apiKey: string): string | Promise<string> | null;
+  getAppKeyForApiKey(apiKey: string): string | Promise<string | null> | null;
 }

--- a/src/apixlib/__tests__/ApiXConfig.test.ts
+++ b/src/apixlib/__tests__/ApiXConfig.test.ts
@@ -1,4 +1,4 @@
-import {ApiXConfig, ApiXConfigKey} from '../ApiXConfig';
+import { ApiXConfig, ApiXConfigKey } from '../ApiXConfig';
 import fs from 'fs';
 
 describe('ApiXConfig', () =>{

--- a/src/apixlib/__tests__/ApiXManager.test.ts
+++ b/src/apixlib/__tests__/ApiXManager.test.ts
@@ -1,21 +1,22 @@
-import request from 'supertest';
-import { ApiXManager } from '../ApiXManager';
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { ApiXConfig, ApiXConfigKey } from '../ApiXConfig';
 import { ApiXAccessLevel } from '../common/ApiXAccessLevel';
 import { ApiXAccessLevelEvaluator } from '../common/ApiXAccessLevelEvaluator';
-import { Express } from 'express';
-import { ApiXConfig, ApiXConfigKey } from '../ApiXConfig';
-import { ApiXMethodCharacteristic } from '../common/methods/ApiXMethodCharacteristic';
+import { ApiXCache } from '../common/ApiXCache';
 import { ApiXDataManager } from '../ApiXDataManager';
 import { ApiXErrorResponseMessage } from '../common/ApiXErrorResponseMessage';
-import { ApiXHttpHeaders } from '../common/ApiXHttpHeaders';
-import { ApiXCache } from '../common/ApiXCache';
-import { ApiXUrlQueryParameter } from '../common/methods/ApiXUrlQueryParameter';
-import { ApiXUrlQueryParameterValidator } from '../common/methods/ApiXUrlQueryParameterValidator';
-import { ApiXUrlQueryParameterProcessor } from '../common/methods/ApiXUrlQueryParameterProcessor';
-import { ApiXRequestInputSchema } from '../common/methods/ApiXRequestInputSchema';
-import { ApiXRequest } from '../common/ApiXRequest';
 import { ApiXHttpBodyValidator } from '../common/methods/ApiXHttpBodyValidator';
-import { ApiXMethod } from '../..';
+import { ApiXHttpHeaders } from '../common/ApiXHttpHeaders';
+import { ApiXManager } from '../ApiXManager';
+import { ApiXMethod } from '../common/methods/ApiXMethod';
+import { ApiXMethodCharacteristic } from '../common/methods/ApiXMethodCharacteristic';
+import { ApiXRequest } from '../common/ApiXRequest';
+import { ApiXRequestInputSchema } from '../common/methods/ApiXRequestInputSchema';
+import { ApiXUrlQueryParameter } from '../common/methods/ApiXUrlQueryParameter';
+import { ApiXUrlQueryParameterProcessor } from '../common/methods/ApiXUrlQueryParameterProcessor';
+import { ApiXUrlQueryParameterValidator } from '../common/methods/ApiXUrlQueryParameterValidator';
+import { Express } from 'express';
+import request from 'supertest';
 
 describe('ApiXManager', () => {
   let app: Express;
@@ -25,6 +26,7 @@ describe('ApiXManager', () => {
   let mockConfig: ApiXConfig;
   let mockCache: jest.Mocked<ApiXCache>;
   let mockValidator: jest.Mocked<ApiXUrlQueryParameterValidator>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mockProcessor: jest.Mocked<ApiXUrlQueryParameterProcessor<any>>;
 
   beforeEach(() => {
@@ -76,7 +78,7 @@ describe('ApiXManager', () => {
       entity: 'entity',
       method: 'method',
       characteristics: new Set([ApiXMethodCharacteristic.PublicUnownedData]),
-      requestHandler: (request, response) => {
+      requestHandler: () => {
         return { success: true };
       }
     });
@@ -85,7 +87,7 @@ describe('ApiXManager', () => {
         entity: 'entity',
         method: 'method',
         characteristics: new Set([ApiXMethodCharacteristic.PublicUnownedData]),
-        requestHandler: (request, response) => {
+        requestHandler: () => {
           return { success: true };
         }
       });
@@ -97,7 +99,7 @@ describe('ApiXManager', () => {
       entity: 'entity',
       method: 'method',
       characteristics: new Set([ApiXMethodCharacteristic.PublicUnownedData]),
-      requestHandler: (request, response) => {
+      requestHandler: () => {
         return { success: true };
       }
     });
@@ -115,7 +117,7 @@ describe('ApiXManager', () => {
       entity: 'entity',
       method: 'method',
       characteristics: new Set([ApiXMethodCharacteristic.PublicUnownedData]),
-      requestHandler: (request, response) => {
+      requestHandler: () => {
         return { success: true };
       }
     });
@@ -138,7 +140,7 @@ describe('ApiXManager', () => {
       entity: 'entity',
       method: 'method',
       characteristics: new Set([ApiXMethodCharacteristic.PublicUnownedData]),
-      requestHandler: (request, response) => {
+      requestHandler: () => {
         return { success: true };
       }
     });
@@ -163,7 +165,7 @@ describe('ApiXManager', () => {
       entity: 'entity',
       method: 'method',
       characteristics: new Set([ApiXMethodCharacteristic.PublicUnownedData]),
-      requestHandler: (request, response) => {
+      requestHandler: () => {
         return { success: true };
       }
     });
@@ -190,7 +192,7 @@ describe('ApiXManager', () => {
       entity: 'entity',
       method: 'method',
       characteristics: new Set([ApiXMethodCharacteristic.PublicUnownedData]),
-      requestHandler: (request, response) => {
+      requestHandler: () => {
         return { success: true };
       }
     });
@@ -222,7 +224,7 @@ describe('ApiXManager', () => {
       entity: 'entity',
       method: 'method',
       characteristics: new Set([ApiXMethodCharacteristic.PublicUnownedData]),
-      requestHandler: (request, response) => {
+      requestHandler: () => {
         return { success: true };
       }
     });
@@ -247,7 +249,7 @@ describe('ApiXManager', () => {
       entity: 'entity',
       method: 'method',
       characteristics: new Set([ApiXMethodCharacteristic.PrivateOwnedData]), /// requires `ResourceOwner`
-      requestHandler: (request, response) => {
+      requestHandler: () => {
         return { success: true };
       }
     });
@@ -279,7 +281,7 @@ describe('ApiXManager', () => {
         new ApiXUrlQueryParameter('param1', mockValidator, mockProcessor, true),
         new ApiXUrlQueryParameter('param2', mockValidator, mockProcessor, true),
       ],
-      requestHandler: (request, response) => {
+      requestHandler: () => {
         return { success: true };
       }
     });
@@ -315,7 +317,7 @@ describe('ApiXManager', () => {
         new ApiXUrlQueryParameter('param1', mockValidator, mockProcessor, true),
         new ApiXUrlQueryParameter('param2', mockValidator, mockProcessor),
       ],
-      requestHandler: (request, response) => {
+      requestHandler: () => {
         return { success: true };
       }
     });
@@ -350,7 +352,7 @@ describe('ApiXManager', () => {
       queryParameters: [
         new ApiXUrlQueryParameter('message', mockValidator, mockProcessor, true)
       ],
-      requestHandler: (request: ApiXRequest<QueryParams>, response) => {
+      requestHandler: (request: ApiXRequest<QueryParams>) => {
         return { success: true, message: request.queryParameters?.message };
       }
     });
@@ -395,7 +397,7 @@ describe('ApiXManager', () => {
       queryParameters: [
         new ApiXUrlQueryParameter('message', mockValidator, mockProcessor, true)
       ],
-      requestHandler: (request: ApiXRequest<QueryParams>, response) => {
+      requestHandler: (request: ApiXRequest<QueryParams>) => {
         return { success: true, message: request.queryParameters?.message };
       }
     });
@@ -444,7 +446,7 @@ describe('ApiXManager', () => {
       method: 'edit',
       httpMethod: 'POST',
       characteristics: new Set([ApiXMethodCharacteristic.PrivateOwnedData]),
-      requestHandler: (request, response) => {
+      requestHandler: (request) => {
         const body = request.jsonBody!;
         return { success: true, message: `Modifying post with ID: ${body.postId} to content: ${body.content}` };
       },
@@ -486,7 +488,7 @@ describe('ApiXManager', () => {
       method: 'edit',
       httpMethod: 'POST',
       characteristics: new Set([ApiXMethodCharacteristic.PrivateOwnedData]),
-      requestHandler: (request, response) => {
+      requestHandler: (request) => {
         const body = request.jsonBody;
         if (body) {
           return { success: true, message: `Modifying post with ID: ${body.postId} to content: ${body.content}` };
@@ -536,7 +538,7 @@ describe('ApiXManager', () => {
       method: 'edit',
       httpMethod: 'POST',
       characteristics: new Set([ApiXMethodCharacteristic.PrivateOwnedData]),
-      requestHandler: (request, response) => {
+      requestHandler: (request) => {
         const body = request.jsonBody!;
         return { success: true, message: `Modifying post with ID: ${body.postId} to content: ${body.content}` };
       },
@@ -574,7 +576,7 @@ describe('ApiXManager', () => {
       method: 'edit',
       httpMethod: 'POST',
       characteristics: new Set([ApiXMethodCharacteristic.PrivateOwnedData]),
-      requestHandler: (request, response) => {
+      requestHandler: (request) => {
         const body = request.body;
         return { success: true, message: `Modifying post with ID: ${body.postId} to content: ${body.content}` };
       }
@@ -610,7 +612,7 @@ describe('ApiXManager', () => {
       method: 'new',
       httpMethod: 'PUT',
       characteristics: new Set([ApiXMethodCharacteristic.PrivateOwnedData]),
-      requestHandler: (request, response) => {
+      requestHandler: (request) => {
         const body = request.body;
         return {
           success: true,
@@ -657,7 +659,7 @@ describe('ApiXManager', () => {
       method: 'delete',
       httpMethod: 'DELETE',
       characteristics: new Set([ApiXMethodCharacteristic.PrivateOwnedData]),
-      requestHandler: (request, response) => {
+      requestHandler: (request) => {
         const body = request.body;
         return {
           success: true,
@@ -694,7 +696,7 @@ describe('ApiXManager', () => {
       entity: 'entity',
       method: 'method',
       characteristics: new Set([ApiXMethodCharacteristic.PublicUnownedData]),
-      requestHandler: (request, response) => {
+      requestHandler: (request) => {
         return { success: true, message: request.query.message };
       }
     });

--- a/src/apixlib/common/__tests__/ApiXRedisStore.test.ts
+++ b/src/apixlib/common/__tests__/ApiXRedisStore.test.ts
@@ -1,4 +1,4 @@
-import {ApiXRedisStore} from '../ApiXRedisStore';
+import { ApiXRedisStore } from '../ApiXRedisStore';
 
 const map: Map<string, string> = new Map();
 

--- a/src/apixlib/common/methods/__tests__/ApiXInputUrlQueryParameterProcessor.test.ts
+++ b/src/apixlib/common/methods/__tests__/ApiXInputUrlQueryParameterProcessor.test.ts
@@ -1,9 +1,14 @@
-import { Request } from 'express';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  ApiXUrlQueryParameter,
+  InvalidParameterError,
+  MissingRequiredParameterError
+} from '../ApiXUrlQueryParameter';
 import { ApiXInputUrlQueryParameterProcessor } from '../ApiXInputUrlQueryParameterProcessor';
-import { ApiXUrlQueryParameter, InvalidParameterError, MissingRequiredParameterError } from '../ApiXUrlQueryParameter';
+import { ApiXRequestInputSchema } from '../ApiXRequestInputSchema';
 import { ApiXUrlQueryParameterProcessor } from '../ApiXUrlQueryParameterProcessor';
 import { ApiXUrlQueryParameterValidator } from '../ApiXUrlQueryParameterValidator';
-import { ApiXRequestInputSchema } from '../ApiXRequestInputSchema';
+import { Request } from 'express';
 
 describe('ApiXInputQueryParameterProcessor', () => {
   let mockValidator: jest.Mocked<ApiXUrlQueryParameterValidator>;

--- a/src/apixlib/common/methods/__tests__/ApiXUrlQueryParameter.test.ts
+++ b/src/apixlib/common/methods/__tests__/ApiXUrlQueryParameter.test.ts
@@ -1,7 +1,12 @@
-import { Request } from 'express';
-import { ApiXUrlQueryParameter, InvalidParameterError, MissingRequiredParameterError } from '../ApiXUrlQueryParameter';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  ApiXUrlQueryParameter,
+  InvalidParameterError,
+  MissingRequiredParameterError
+} from '../ApiXUrlQueryParameter';
 import { ApiXUrlQueryParameterProcessor } from '../ApiXUrlQueryParameterProcessor';
 import { ApiXUrlQueryParameterValidator } from '../ApiXUrlQueryParameterValidator';
+import { Request } from 'express';
 
 describe(`ApiXUrlQueryParameter`, () => {
   let mockValidator: jest.Mocked<ApiXUrlQueryParameterValidator>;

--- a/src/apixlib/common/utils/__tests__/makeApiXErrorResponse.test.ts
+++ b/src/apixlib/common/utils/__tests__/makeApiXErrorResponse.test.ts
@@ -1,4 +1,4 @@
-import {makeApiXErrorResponse} from '../makeApiXErrorResponse';
+import { makeApiXErrorResponse } from '../makeApiXErrorResponse';
 
 describe('Verify correct error object is returned', () => {
   test('makeApiXErrorMessage', () => {


### PR DESCRIPTION
# Beta 2 of API-X v2
- App Cache is not required for security purposes and simplicity.
- Request signature computation more accurate (Request HTTP Body keys are sorted recursively).
- ApiXDataManager#getAppKeyForApiKey can now return null from the API in async functions.
- Formatting updates.